### PR TITLE
Fix path to vite configuration stub

### DIFF
--- a/src/AdminLTELocalizedPreset.php
+++ b/src/AdminLTELocalizedPreset.php
@@ -55,7 +55,7 @@ class AdminLTELocalizedPreset extends Preset
      */
     protected static function updateViteConfiguration()
     {
-        copy(__DIR__.'../adminlte-stubs/bootstrap/vite.config.js', base_path('vite.config.js'));
+        copy(__DIR__.'/../adminlte-stubs/bootstrap/vite.config.js', base_path('vite.config.js'));
     }
 
     /**


### PR DESCRIPTION
when running `php artisan ui adminlte-localized --auth` an error is thrown because the path to the `vite.config.js` stub file is missing a directory separator  